### PR TITLE
Choi kernel

### DIFF
--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -277,7 +277,12 @@ class KernelPCA(TransformerMixin, BaseEstimator):
         self : object
             Returns the instance itself.
         """
-        X = self._validate_data(X, accept_sparse='csr', copy=self.copy_X)
+        if self.kernel in ('choi',):
+            force_all_finite = 'allow-nan'
+        else:
+            force_all_finite = True
+
+        X = self._validate_data(X, accept_sparse='csr', copy=self.copy_X, force_all_finite=force_all_finite)
         self._centerer = KernelCenterer()
         K = self._get_kernel(X)
         self._fit_transform(K)

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -147,7 +147,7 @@ class KernelPCA(TransformerMixin, BaseEstimator):
                  alpha=1.0, fit_inverse_transform=False, eigen_solver='auto',
                  tol=0, max_iter=None, remove_zero_eig=False,
                  random_state=None, copy_X=True, n_jobs=None):
-        if fit_inverse_transform and kernel == 'precomputed':
+        if fit_inverse_transform and kernel in ('precomputed', 'choi',):
             raise ValueError(
                 "Cannot fit_inverse_transform with a precomputed kernel.")
         self.n_components = n_components

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -22,25 +22,25 @@ def test_choi_kernel_pca():
 
     # transform fit data
     choi_kpca = KernelPCA(4, kernel='choi', eigen_solver='auto', fit_inverse_transform=True)
-    # X_fit_transformed = choi_kpca.fit_transform(X_fit)
-    #
-    # rbf_kpca = KernelPCA(4, kernel='rbf', eigen_solver='auto', fit_inverse_transform=True)
-    # X_fit_transformed2 = rbf_kpca.fit_transform(X_fit)
-    # assert_array_almost_equal(np.abs(X_fit_transformed),
-    #                           np.abs(X_fit_transformed2))
-    #
-    # # non-regression test: previously, gamma would be 0 by default,
-    # # forcing all eigenvalues to 0 under the poly kernel
-    # assert X_fit_transformed.size != 0
-    #
-    # # transform new data
-    # X_pred_transformed = choi_kpca.transform(X_pred)
-    # assert (X_pred_transformed.shape[1] ==
-    #         X_fit_transformed.shape[1])
-    #
-    # # inverse transform
-    # X_pred2 = choi_kpca.inverse_transform(X_pred_transformed)
-    # assert X_pred2.shape == X_pred.shape
+    X_fit_transformed = choi_kpca.fit_transform(X_fit)
+
+    rbf_kpca = KernelPCA(4, kernel='rbf', eigen_solver='auto', fit_inverse_transform=True)
+    X_fit_transformed2 = rbf_kpca.fit_transform(X_fit)
+    assert_array_almost_equal(np.abs(X_fit_transformed),
+                              np.abs(X_fit_transformed2))
+
+    # non-regression test: previously, gamma would be 0 by default,
+    # forcing all eigenvalues to 0 under the poly kernel
+    assert X_fit_transformed.size != 0
+
+    # transform new data
+    X_pred_transformed = choi_kpca.transform(X_pred)
+    assert (X_pred_transformed.shape[1] ==
+            X_fit_transformed.shape[1])
+
+    # inverse transform
+    X_pred2 = choi_kpca.inverse_transform(X_pred_transformed)
+    assert X_pred2.shape == X_pred.shape
 
     X_fit[0, 0] = np.nan
     X_fit_transformed = choi_kpca.fit_transform(X_fit)

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -15,6 +15,37 @@ from sklearn.metrics.pairwise import rbf_kernel
 from sklearn.utils.validation import _check_psd_eigenvalues
 
 
+def test_choi_kernel_pca():
+    rng = np.random.RandomState(0)
+    X_fit = rng.random_sample((5, 4))
+    X_pred = rng.random_sample((2, 4))
+
+    # transform fit data
+    choi_kpca = KernelPCA(4, kernel='choi', eigen_solver='auto', fit_inverse_transform=True)
+    # X_fit_transformed = choi_kpca.fit_transform(X_fit)
+    #
+    # rbf_kpca = KernelPCA(4, kernel='rbf', eigen_solver='auto', fit_inverse_transform=True)
+    # X_fit_transformed2 = rbf_kpca.fit_transform(X_fit)
+    # assert_array_almost_equal(np.abs(X_fit_transformed),
+    #                           np.abs(X_fit_transformed2))
+    #
+    # # non-regression test: previously, gamma would be 0 by default,
+    # # forcing all eigenvalues to 0 under the poly kernel
+    # assert X_fit_transformed.size != 0
+    #
+    # # transform new data
+    # X_pred_transformed = choi_kpca.transform(X_pred)
+    # assert (X_pred_transformed.shape[1] ==
+    #         X_fit_transformed.shape[1])
+    #
+    # # inverse transform
+    # X_pred2 = choi_kpca.inverse_transform(X_pred_transformed)
+    # assert X_pred2.shape == X_pred.shape
+
+    X_fit[0, 0] = np.nan
+    X_fit_transformed = choi_kpca.fit_transform(X_fit)
+
+
 def test_kernel_pca():
     rng = np.random.RandomState(0)
     X_fit = rng.random_sample((5, 4))

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -14,6 +14,7 @@ from functools import partial
 import warnings
 
 import numpy as np
+from numba import njit
 from scipy.spatial import distance
 from scipy.sparse import csr_matrix
 from scipy.sparse import issparse
@@ -442,6 +443,7 @@ def _nan_fill_row_norm(r, fill_value: float = 0.):
     return np.sum(p)
 
 
+@njit
 def _nan_fill_dot(X, Y, fill_values: np.ndarray):
     if X.shape[1] != fill_values.shape[0]:
         raise ValueError('X and fill_values have incompatible shapes')
@@ -456,7 +458,7 @@ def _nan_fill_dot(X, Y, fill_values: np.ndarray):
                 if np.isnan(v1[k]) and np.isnan(v2[k]):
                     pass
                 elif np.isnan(v1[k]) or np.isnan(v2[k]):
-                    s += -fill_values[k]
+                    s += fill_values[k]
                 else:
                     s += v1[k] * v2[k]
 
@@ -489,7 +491,7 @@ def nan_filled_euclidean_distances(X, fill_values, Y=None, squared=False, missin
         YY = YY[np.newaxis, :]
 
     # if dtype is already float64, no need to chunk and upcast
-    distances = - 2 * _nan_fill_dot(X, Y, fill_values)
+    distances = - 2 * _nan_fill_dot(X, Y, -fill_values)
     # distances = - 2 * np.dot(X, Y.T)
     distances += XX
     distances += YY

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -467,17 +467,8 @@ def _nan_fill_dot(X, Y, fill_values: np.ndarray):
     return p
 
 
-def nan_filled_euclidean_distances(X, fill_values, Y=None, squared=False, missing_values=np.nan, copy=True):
-    if X.dtype == np.float32 or (Y is not None and Y.dtype == np.float32):
-        raise NotImplementedError('X and Y must be np.float64 type')
-
+def nan_filled_euclidean_distances(X, fill_values, Y=None, squared=False, copy=True):
     X, Y = check_pairwise_arrays(X, Y, accept_sparse=False, force_all_finite='allow-nan', copy=copy)
-
-    # Get missing mask for X
-    missing_X = _get_mask(X, missing_values)
-
-    # Get missing mask for Y
-    missing_Y = missing_X if Y is X else _get_mask(Y, missing_values)
 
     # calculate euclidean distances
     XX = np.apply_along_axis(_nan_fill_row_norm, 1, X)


### PR DESCRIPTION
Created the 'choi' kernel option for the KernelPCA class. The 'choi' kernel behaves indentically to the 'rbf' kernel when there are no missing values. When one of the column values are missing and the other is present, the 'choi' kernel assigns a multiple of the standard deviation as the distance measure instead of the 2-norm. When both column values are missing, the distance is set to 0.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
